### PR TITLE
Add support for the lightspeed receiver of the G915 wireless keyboard

### DIFF
--- a/hid-logitech-dj.c
+++ b/hid-logitech-dj.c
@@ -2085,6 +2085,9 @@ static const struct hid_device_id logi_dj_receivers[] = {
 	  HID_USB_DEVICE(USB_VENDOR_ID_LOGITECH,
 		USB_DEVICE_ID_LOGITECH_NANO_RECEIVER_LIGHTSPEED_1_2),
 	 .driver_data = recvr_type_gaming_hidpp_ls_1_2},
+	{ /* Logitech lightspeed receiver (0xc541) */
+	  HID_USB_DEVICE(USB_VENDOR_ID_LOGITECH, 0xc541),
+	 .driver_data = recvr_type_gaming_hidpp_ls_1_2},
 
 	{ /* Logitech 27 MHz HID++ 1.0 receiver (0xc513) */
 	  HID_USB_DEVICE(USB_VENDOR_ID_LOGITECH, USB_DEVICE_ID_MX3000_RECEIVER),


### PR DESCRIPTION
I added the lightspeed receiver of the G915 wireless keyboard.
Accept this pull request please, so this gets into your aur-package.